### PR TITLE
Refund transaction support

### DIFF
--- a/api/Api/Data/PaymentActionInterface.php
+++ b/api/Api/Data/PaymentActionInterface.php
@@ -11,4 +11,5 @@ interface PaymentActionInterface
 {
     const AUTHORIZE = 'authorize';
     const AUTHORIZE_CAPTURE = 'authorize_capture';
+    const REFUND = 'refund';
 }

--- a/card-gateway/etc/di.xml
+++ b/card-gateway/etc/di.xml
@@ -12,6 +12,7 @@
             <argument name="commands" xsi:type="array">
                 <item name="authorize" xsi:type="string">PronkoLiqPayAuthCommand</item>
                 <item name="capture" xsi:type="string">PronkoLiqPayCaptureCommand</item>
+                <item name="refund" xsi:type="string">PronkoLiqPayRefundCommand</item>
             </argument>
         </arguments>
     </virtualType>
@@ -99,10 +100,57 @@
         </arguments>
     </virtualType>
 
+    <!-- LiqPay Refund Command -->
+    <virtualType name="PronkoLiqPayRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">PronkoLiqPayRequestRefundBuilderComposite</argument>
+            <argument name="transferFactory" xsi:type="object">Pronko\LiqPayGateway\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Pronko\LiqPayGateway\Gateway\Http\Client</argument>
+            <argument name="handler" xsi:type="object">PronkoLiqPayRefundHandler</argument>
+            <argument name="validator" xsi:type="object">PronkoLiqPayRefundResponseValidatorPool</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- LiqPay Request Refund Builder -->
+    <virtualType name="PronkoLiqPayRequestRefundBuilderComposite" type="Pronko\LiqPayGateway\Gateway\Request\RequestBuilder">
+        <arguments>
+            <argument name="builder" xsi:type="object">PronkoLiqPayRefundBuilderComposite</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- LiqPay Request Refund Builder Composite -->
+    <virtualType name="PronkoLiqPayRefundBuilderComposite" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="general" xsi:type="string">Pronko\LiqPayGateway\Gateway\Request\Builder\GeneralBuilder</item>
+                <item name="action" xsi:type="string">Pronko\LiqPayGateway\Gateway\Request\Builder\RefundActionBuilder</item>
+                <item name="order" xsi:type="string">Pronko\LiqPayGateway\Gateway\Request\Builder\RefundOrderBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <!-- LiqPay Payment Refund Handler-->
+    <virtualType name="PronkoLiqPayRefundHandler" type="Magento\Payment\Gateway\Response\HandlerChain">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="refund" xsi:type="string">Pronko\LiqPayGateway\Gateway\Response\RefundHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="PronkoLiqPayResponseValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorComposite">
         <arguments>
             <argument name="validators" xsi:type="array">
                 <item name="general" xsi:type="string">Pronko\LiqPayGateway\Gateway\Validator\GeneralResponseValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <!-- LiqPay Payment Refund Validator Pool-->
+    <virtualType name="PronkoLiqPayRefundResponseValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorComposite">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="refund" xsi:type="string">Pronko\LiqPayGateway\Gateway\Validator\RefundResponseValidator</item>
             </argument>
         </arguments>
     </virtualType>

--- a/gateway/Gateway/Request/Builder/RefundActionBuilder.php
+++ b/gateway/Gateway/Request/Builder/RefundActionBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pronko\LiqPayGateway\Gateway\Request\Builder;
+
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Pronko\LiqPayApi\Api\Data\PaymentActionInterface;
+use Pronko\LiqPaySdk\Api\RequestFieldsInterface as RequestFields;
+
+/**
+ * Class RefundActionBuilder
+ */
+class RefundActionBuilder implements BuilderInterface
+{
+
+    /**
+     * Builds ENV request
+     *
+     * @param array $buildSubject
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        return [
+            RequestFields::ACTION => PaymentActionInterface::REFUND,
+        ];
+    }
+}

--- a/gateway/Gateway/Request/Builder/RefundOrderBuilder.php
+++ b/gateway/Gateway/Request/Builder/RefundOrderBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pronko\LiqPayGateway\Gateway\Request\Builder;
+
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Magento\Payment\Helper\Formatter;
+use Pronko\LiqPayGateway\Gateway\Request\OrderIdProvider;
+use Pronko\LiqPaySdk\Api\RequestFieldsInterface as RequestFields;
+
+/**
+ * Class RefundOrderBuilder
+ */
+class RefundOrderBuilder implements BuilderInterface
+{
+
+    use Formatter;
+
+    /**
+     * @var OrderIdProvider
+     */
+    private $orderIdProvider;
+
+    /**
+     * RefundOrderBuilder constructor.
+     * @param OrderIdProvider $orderIdProvider
+     */
+    public function __construct(OrderIdProvider $orderIdProvider)
+    {
+        $this->orderIdProvider = $orderIdProvider;
+    }
+
+    /**
+     * Builds ENV request
+     *
+     * @param array $buildSubject
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        /** @var OrderAdapterInterface $order */
+        $order = $buildSubject['payment']->getOrder();
+
+        return [
+            RequestFields::AMOUNT => $this->formatPrice($buildSubject['amount']),
+            RequestFields::ORDER_ID => $this->orderIdProvider->get($order),
+        ];
+    }
+}

--- a/gateway/Gateway/Request/Builder/RefundOrderBuilder.php
+++ b/gateway/Gateway/Request/Builder/RefundOrderBuilder.php
@@ -16,8 +16,6 @@ use Pronko\LiqPaySdk\Api\RequestFieldsInterface as RequestFields;
 class RefundOrderBuilder implements BuilderInterface
 {
 
-    use Formatter;
-
     /**
      * @var OrderIdProvider
      */
@@ -44,7 +42,7 @@ class RefundOrderBuilder implements BuilderInterface
         $order = $buildSubject['payment']->getOrder();
 
         return [
-            RequestFields::AMOUNT => $this->formatPrice($buildSubject['amount']),
+            RequestFields::AMOUNT => $buildSubject['amount'],
             RequestFields::ORDER_ID => $this->orderIdProvider->get($order),
         ];
     }

--- a/gateway/Gateway/Response/RefundHandler.php
+++ b/gateway/Gateway/Response/RefundHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pronko\LiqPayGateway\Gateway\Response;
+
+use Magento\Payment\Gateway\Response\HandlerInterface;
+use Magento\Payment\Model\InfoInterface;
+use Pronko\LiqPaySdk\Api\ResponseFieldsInterface;
+
+/**
+ * Class PaymentHandler
+ */
+class RefundHandler implements HandlerInterface
+{
+    /**
+     * @var array
+     */
+    private $additionalInformation = [
+        ResponseFieldsInterface::ACTION,
+        ResponseFieldsInterface::PAYMENT_ID,
+        ResponseFieldsInterface::STATUS,
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function handle(array $handlingSubject, array $response)
+    {
+        /** @var InfoInterface $payment */
+        $payment = $handlingSubject['payment']->getPayment();
+
+        foreach ($this->additionalInformation as $responseKey) {
+            if (!empty($response[$responseKey])) {
+                $payment->setAdditionalInformation($responseKey, $response[$responseKey]);
+            }
+        }
+    }
+}

--- a/gateway/Gateway/Validator/RefundResponseValidator.php
+++ b/gateway/Gateway/Validator/RefundResponseValidator.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright © Pronko Consulting (https://www.pronkoconsulting.com)
+ * See LICENSE for the license details.
+ */
+declare(strict_types=1);
+
+namespace Pronko\LiqPayGateway\Gateway\Validator;
+
+use Magento\Payment\Gateway\Validator\AbstractValidator;
+
+/**
+ * Class GeneralResponseValidator
+ */
+class RefundResponseValidator extends AbstractValidator
+{
+    /**
+     * @inheritdoc
+     */
+    public function validate(array $validationSubject)
+    {
+        $response = $validationSubject['response'];
+
+        $isValid = true;
+        $errorMessages = [];
+
+        foreach ($this->getResponseValidators() as $validator) {
+            $validationResult = $validator($response);
+
+            if (!$validationResult[0]) {
+                $isValid = $validationResult[0];
+                $this->addErrorMessages($errorMessages, $validationResult);
+            }
+        }
+
+        return $this->createResult($isValid, $errorMessages);
+    }
+
+    /**
+     * @param array $errorMessages
+     * @param array $validationResult
+     */
+    private function addErrorMessages(array &$errorMessages, $validationResult)
+    {
+        $errorMessages = array_merge($errorMessages, $validationResult[1]);
+    }
+
+    /**
+     * @return array
+     */
+    private function getResponseValidators()
+    {
+        return [
+            function ($response) {
+                return [
+                    isset($response['action']),
+                    [__('LiqPay Action is missing in the response')]
+                ];
+            },
+            function ($response) {
+                return [
+                    isset($response['payment_id']),
+                    [__('LiqPay Payment Id is missing in the response')]
+                ];
+            },
+            function ($response) {
+                return [
+                    isset($response['status']) && in_array($response['status'], ['success', 'reserved']),
+                    [__('LiqPay server returned an error in the response')]
+                ];
+            },
+        ];
+    }
+}

--- a/gateway/etc/config.xml
+++ b/gateway/etc/config.xml
@@ -19,6 +19,7 @@
                 <is_gateway>1</is_gateway>
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
+                <can_refund>1</can_refund>
                 <debug>1</debug>
             </pronko_liqpay>
         </payment>

--- a/sdk/Api/ResponseFieldsInterface.php
+++ b/sdk/Api/ResponseFieldsInterface.php
@@ -26,4 +26,5 @@ interface ResponseFieldsInterface
     const SENDER_CARD_MASK = 'sender_card_mask2';
     const SENDER_CARD_BANK = 'sender_card_bank';
     const SENDER_CARD_TYPE = 'sender_card_type';
+    const STATUS = 'status';
 }


### PR DESCRIPTION
Created online credit memo (refund) support for Liqpay.
Issue https://github.com/mcspronko/liqpay-magento2/issues/44

One issue.
For the refund transaction the Liqpay API doesn't return a transaction_id to store to the payment.
Also for this transaction shouldn't we set the parent transaction id with the one of the pay or auth transaction?