### PR TITLE
Fixed missing autoload declaration in composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
       "redirect/registration.php",
       "widget/registration.php",
       "api/registration.php",
-      "customer/registration.php"
+      "customer/registration.php",
+      "sdk/registration.php"
     ],
     "psr-4": {
       "Pronko\\LiqPayCheckout\\": "checkout",
@@ -63,7 +64,8 @@
       "Pronko\\LiqPayRedirect\\": "redirect",
       "Pronko\\LiqPayWidget\\": "widget",
       "Pronko\\LiqPayCustomer\\": "customer",
-      "Pronko\\LiqPayApi\\": "api"
+      "Pronko\\LiqPayApi\\": "api",
+      "Pronko\\LiqPaySdk\\": "sdk"
     }
   },
   "repositories": [


### PR DESCRIPTION
When user install liqpay-magento2 via composer, later after executing `php bin/magento setup:upgrade` or any other `bin/magento` command, he'll got following message: **`Constant name is expected.`** 

Exception throws in `vendor/magento/framework/Data/Argument/Interpreter/Constant.php` file, while trying to load `Pronko\LiqPaySdk\Api\ApiUrlInterface::API_URL` constant variable, that is declared in `vendor/pronko/liqpay-magento2/gateway/etc/di.xml`